### PR TITLE
Fix attribute formatting for mangled names

### DIFF
--- a/asagg_lib/asagg.py
+++ b/asagg_lib/asagg.py
@@ -36,7 +36,7 @@ class Asagg(ABC):
 
     @abstractmethod
     def __init__(self):
-        """Absatract method"""
+        """Abstract method"""
         pass
 
     @staticmethod
@@ -182,7 +182,7 @@ class Asagg(ABC):
     @staticmethod
     def __default_function_setter(self: object, attr: str, value: Any) -> None:
         """
-        This method is responsable to set the value on object
+        This method is responsible for setting the value on the object
 
         Parameters:
             self: Object that you want to create a set function
@@ -205,7 +205,7 @@ class Asagg(ABC):
     @staticmethod
     def __default_function_getter(self: Any, attr: str) -> Any:
         """
-        This method is responsable to get the value on object
+        This method is responsible for getting the value from the object
 
         Parameters:
             self: Object that you want to create a set function

--- a/asagg_lib/utils/formatter.py
+++ b/asagg_lib/utils/formatter.py
@@ -16,9 +16,17 @@ def format_attributes_names(
     """
     attributes_formatted: list[str] = []
     for attr in attributes:
-        attr = attr.replace("_", "")
-        if classname in attr:
-            attr = attr.replace(classname, "")
+        # remove leading underscores that mark protected or private members
+        attr = attr.lstrip("_")
+
+        # handle Python name mangling for private attributes by removing the
+        # class name if it is present at the start of the attribute
+        if classname and attr.startswith(classname):
+            attr = attr[len(classname) :]
+            # after removing the class name there may still be a leading
+            # underscore left from the mangling
+            attr = attr.lstrip("_")
+
         attributes_formatted.append(attr)
 
     return attributes_formatted

--- a/asagg_lib/utils/formatter.py
+++ b/asagg_lib/utils/formatter.py
@@ -1,14 +1,17 @@
 def format_attributes_names(
     attributes: list[str], classname: str = ""
 ) -> list[str]:
-    """
-    Format attributes to make a new attribute and remove classname if attribute name contains it
+    """Format attribute names by cleaning mangled prefixes.
 
     Parameters:
-         attributes: list of all attribute that you want format
-         classname: name of class that you retrive the attributes
+        attributes: list[str]
+            List of attribute names to format.
+        classname: str
+            Optional class name used when removing mangled prefixes.
+
     Returns:
-        return all attributes formatted to make new public attributes
+        list[str]:
+            A list containing the formatted attribute names.
 
     Examples:
         >>> format_attributes_names(["_foo", "_Square_foo"], "Square")

--- a/tests/utilities/test_formatter.py
+++ b/tests/utilities/test_formatter.py
@@ -17,6 +17,16 @@ class TestFormatter(unittest.TestCase):
 
         self.assertEqual(attributes_formatteds, ["foo", "foo"])
 
+    def test_it_should_preserve_middle_underscores(self):
+        attributes = ["_my_private_attr", "_Square_my_private_attr"]
+        attributes_formatteds = format_attributes_names(
+            attributes, classname="Square"
+        )
+
+        self.assertEqual(
+            attributes_formatteds, ["my_private_attr", "my_private_attr"]
+        )
+
     def test_it_should_not_be_able_to_formar_privates_and_protected_attributes_with_missign_values(
         self,
     ):

--- a/tests/utilities/test_formatter.py
+++ b/tests/utilities/test_formatter.py
@@ -6,13 +6,13 @@ from asagg_lib.utils.formatter import format_attributes_names
 class TestFormatter(unittest.TestCase):
     def setUp(self):
         super(TestFormatter, self).setUp()
-        self.attrinutes = ["_foo", "_Square_foo"]
+        self.attributes = ["_foo", "_Square_foo"]
 
     def test_it_should_be_able_to_format_privates_and_protected_attributes(
         self,
     ):
         attributes_formatteds = format_attributes_names(
-            self.attrinutes, classname="Square"
+            self.attributes, classname="Square"
         )
 
         self.assertEqual(attributes_formatteds, ["foo", "foo"])
@@ -27,9 +27,9 @@ class TestFormatter(unittest.TestCase):
             attributes_formatteds, ["my_private_attr", "my_private_attr"]
         )
 
-    def test_it_should_not_be_able_to_formar_privates_and_protected_attributes_with_missign_values(
+    def test_it_should_not_format_attributes_without_classname(
         self,
     ):
-        attributes_formatteds = format_attributes_names(self.attrinutes)
+        attributes_formatteds = format_attributes_names(self.attributes)
 
-        self.assertFalse(attributes_formatteds == ["foo", "foo"])
+        self.assertEqual(attributes_formatteds, ["foo", "Square_foo"])


### PR DESCRIPTION
## Summary
- preserve internal underscores when formatting attribute names
- add unit test for underscore-preserving behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4bd008888321b8ae5bf949193dd6