### PR TITLE
Fix init member check in extractor

### DIFF
--- a/asagg_lib/utils/extractor.py
+++ b/asagg_lib/utils/extractor.py
@@ -42,7 +42,7 @@ class Extractor(ABC):
         """
         attributes = []
         for member in getmembers(_class):
-            if "__init__" in member:
+            if member[0] == "__init__":
                 attributes = member[1].__code__.co_names
                 break
 


### PR DESCRIPTION
## Summary
- fix loop condition in `Extractor.extract_attributes`
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4cc4bb5c83218032a446e7b0dc8c