### PR TITLE
Fix docstring typo and add return

### DIFF
--- a/asagg_lib/asagg.py
+++ b/asagg_lib/asagg.py
@@ -182,7 +182,7 @@ class Asagg(ABC):
     @staticmethod
     def __default_function_setter(self: object, attr: str, value: Any) -> None:
         """
-        This method is responsable to set the value on object
+        This method is responsible to set the value on object
 
         Parameters:
             self: Object that you want to create a set function
@@ -190,6 +190,7 @@ class Asagg(ABC):
             value: value that you want to set in attribute
 
         Returns:
+            None
 
         """
         type_to_compare = type(getattr(self, attr))
@@ -205,7 +206,7 @@ class Asagg(ABC):
     @staticmethod
     def __default_function_getter(self: Any, attr: str) -> Any:
         """
-        This method is responsable to get the value on object
+        This method is responsible to get the value on object
 
         Parameters:
             self: Object that you want to create a set function


### PR DESCRIPTION
## Summary
- fix typos in `_default_function_setter` and `_default_function_getter` docstrings
- document missing return value for `_default_function_setter`

## Testing
- `pytest -s -x -vv`

------
https://chatgpt.com/codex/tasks/task_e_684b4ccdc6e483219d8bd142ebefdc7f